### PR TITLE
fix(test) CI Infra permission resetter

### DIFF
--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -20,13 +20,16 @@ sudo apt-get -y install docker-compose
 #Add Docker to sudoers group
 sudo usermod -aG docker ${USER}
 newgrp docker &
-# Hook up to GH Actions
+# Install & Setup GH Actions Runner
 mkdir actions-runner && cd actions-runner
 curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
-sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work # fixes the test cruft cleanup issue
+# CI Permission Issue
+sudo touch /etc/cron.d/ci_permissions_resetter
+sudo echo "* * * * * root chown -R $USER:$USER /home/ubuntu/actions-runner/_work" >  /etc/cron.d/ci_permissions_resetter 
+# Start GH Actions
 sudo ./svc.sh install
 sudo ./svc.sh start
 # Reboot Machine


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
The CI infrastructure is corrupted by docker crufts from load tests, its affecting next run in the cleanup step.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
Allow the lxc user full control to that test folder