### PR TITLE
fix(test) enable docker logs & introduce sleep before tests

### DIFF
--- a/graphql/e2e/multi_tenancy/multi_tenancy_test.go
+++ b/graphql/e2e/multi_tenancy/multi_tenancy_test.go
@@ -52,6 +52,8 @@ var (
 // Whenever schema is updated in a dgraph alpha for one group for any namespace,
 // that update should also be propagated to alpha nodes in other groups.
 func TestSchemaSubscribe(t *testing.T) {
+	// TODO: need to fix the race condition for license propagation, the sleep helps propagate the EE license correctly
+	time.Sleep(time.Second * 60)
 	header := http.Header{}
 	header.Set(accessJwtHeader, testutil.GrootHttpLogin(groupOneAdminServer).AccessJwt)
 	schema := `

--- a/systest/acl/restore/acl_restore_test.go
+++ b/systest/acl/restore/acl_restore_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
@@ -84,6 +85,8 @@ func sendRestoreRequest(t *testing.T, location, backupId string, backupNum int) 
 }
 
 func TestAclCacheRestore(t *testing.T) {
+	// TODO: need to fix the race condition for license propagation, the sleep helps propagate the EE license correctly
+	time.Sleep(time.Second * 60)
 	disableDraining(t)
 	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
 	require.NoError(t, err)

--- a/t/t.go
+++ b/t/t.go
@@ -168,7 +168,7 @@ func outputLogs(prefix string) {
 		out, err := logCmd.CombinedOutput()
 		x.Check(err)
 		f.Write(out)
-		// fmt.Printf("Docker logs for %s is %s with error %+v ", c.ID, string(out), err)
+		fmt.Printf("Docker logs for %s is %s with error %+v ", c.ID, string(out), err)
 	}
 	for i := 0; i <= 3; i++ {
 		printLogs("zero" + strconv.Itoa(i))


### PR DESCRIPTION
## Problem
The current test harness has race conditions with EE license checks

## Solution
Introduce sleeps to facilitate the EE license checks
Open Docker logs